### PR TITLE
Improves colour support and adds more tests for colours, styles, and keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/davidcralph/leeks.js"
   },
   "scripts": {
-    "test": "jest --coverage",
+    "test": "jest",
     "test:watch": "jest --watchAll",
     "build": "npm run clean && tsc",
     "clean": "rm -rf dist && rm -rf node_modules && npm i"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,6 +31,17 @@ describe('Styles', () => {
       expect(leeks.styles[name]('test')).toBe(expected);
     });
   }
+
+  for (const name of Object.keys(styles)) {
+    test(`Expect style '${name}' to resolve correctly without being enabled`, () => {
+      leeks.disableColours();
+
+      const expected = 'test';
+      expect(leeks.styles[name]('test')).toBe(expected);
+
+      leeks.enableColours();
+    });
+  }
 });
 
 describe('Keywords', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,54 @@
-import leeks from '../dist/index.js';
+import colours from './data/Colours';
+import styles from './data/Styles';
+import keywords from './data/Keywords';
 
-test('Colours and background colours', () => {
-  const expectedColour = `\x1b[32m$test\x1b[0m`;
+import * as leeks from '.';
 
-  expect(leeks.green('test')).toBe(expectedColour);
+describe('Colors and background colours', () => {
+  for (const [name, code] of Object.entries(colours)) {
+    test(`Expect color '${name}' to resolve correctly while enabled`, () => {
+      const expected = `\x1b[${code}mtest\x1b[0m`;
+      expect(leeks.colors[name]('test')).toBe(expected);
+    });
+  }
+
+  for (const name of Object.keys(colours)) {
+    test(`Expect color '${name}' to resolve correctly without being enabled`, () => {
+      leeks.disableColours();
+
+      const expected = 'test';
+      expect(leeks.colors[name]('test')).toBe(expected);
+
+      leeks.enableColours();
+    });
+  }
+});
+
+describe('Styles', () => {
+  for (const [name, code] of Object.entries(styles)) {
+    test(`Expect style '${name}' to resolve correctly while enabled`, () => {
+      const expected = `\x1b[${code}mtest\x1b[0m`;
+      expect(leeks.styles[name]('test')).toBe(expected);
+    });
+  }
+});
+
+describe('Keywords', () => {
+  for (const [name, [r, g, b]] of Object.entries(keywords)) {
+    test(`Expect keyword '${name}' to resolve correctly while colours are enabled`, () => {
+      const expected = '\033' + `[38;2;${r};${g};${b}mtest\x1b[0m`;
+      expect(leeks.keywords[name]('test')).toBe(expected);
+    });
+  }
+
+  for (const name of Object.keys(keywords)) {
+    test(`Expect keyword '${name}' to resolve correctly while colours are disabled`, () => {
+      leeks.disableColors();
+
+      const expected = 'test';
+      expect(leeks.keywords[name]('test')).toBe(expected);
+
+      leeks.enableColors();
+    });
+  }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ for (const c in Colours) {
  */
 const styles = [];
 for (const s in Styles) {
-  styles[s] = (t: string) => `\x1b[${Styles[s]}m${t}\x1b[0m`;
+  styles[s] = (t: string) => enabled ? `\x1b[${Styles[s]}m${t}\x1b[0m` : t;
 }
 
 /** 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,17 @@ import Keywords from './data/Keywords';
 import ShortCodes from './data/ShortCodes';
 
 const isNode = typeof process !== 'undefined';
+const hasColors = typeof process.stdout?.hasColors !== 'undefined';
 
 /**
  * Check if colours are supported (returns false on browser)
  */
-const supports = isNode ?
-  !('NO_COLOR' in process.env) && process.env.FORCE_COLOR !== '0' // NO_COLOR support and FORCE_COLOR=0 (disabling colour support)
-  && process.stdout.hasColors && process.stdout.hasColors() == true
-  : false;
+const colorsEnabled = !isNode ? false : (
+  (!('NO_COLOR' in process.env) && process.env.FORCE_COLOR !== '0') ||
+  (hasColors ? process.stdout.hasColors() : false)
+);
 
-// Enable/disable support for colours, by default checks for support using the function
-let enabled = supports ? true : false;
+let enabled = colorsEnabled;
 
 /** 
  * Change the colour of the given text (List: https://docs.davidcralph.co.uk/#/leeks) 
@@ -186,8 +186,8 @@ export function disableColours() {
 
 export {
   colours as colors,
-  supports as supportsColor,
-  supports as supportsColour,
+  colorsEnabled as supportsColor,
+  colorsEnabled as supportsColour,
   enableColours as enableColors,
   disableColours as disableColors,
   colours,


### PR DESCRIPTION
This PR includes improved colour support with Bun (https://github.com/oven-sh/bun) since **Bun** doesn't support `process.stdout.hasColors`.

Before with **Bun**:
![](https://noel-is.gay/images/816c54f7.png)

After with **Bun**:
![](https://noel-is.gay/images/83ee2c85.png)

This PR also includes a test suite for testing colors, styles, and keywords with and without colour support with explicit `disableColors`/`enableColors` calls.

The PR removes the `--coverage` flag when testing since `--coverage` enables the **'use strict';** string in JavaScript, which errors:

![](https://noel-is.gay/images/ce8e9606.png)